### PR TITLE
Fix pagination logic resulting in infinite loops on some streams.

### DIFF
--- a/tap_autopilot/__init__.py
+++ b/tap_autopilot/__init__.py
@@ -185,17 +185,16 @@ def gen_request(STATE, endpoint, params=None):
     source_key = parse_key_from_source(source)
 
     with metrics.record_counter(source) as counter:
-        while True:
+        bookmark = ""
+        while bookmark is not None:
             data = request(endpoint, params).json()
 
             for row in data[source_key]:
                 counter.increment()
                 yield row
 
-            if "bookmark" in data:
-                params["bookmark"] = data["bookmark"]
-            else:
-                break
+            bookmark = data.get("bookmark", None)
+            params["bookmark"] = bookmark
 
 
 def sync_contacts(STATE, stream):

--- a/tap_autopilot/__init__.py
+++ b/tap_autopilot/__init__.py
@@ -175,17 +175,9 @@ def request(url, params=None):
 
 
 def gen_request(STATE, endpoint, params=None):
-    '''Generate a request that will iterate through the results
-    and paginate through the responses until the amount of results
-    returned is less than 100, the amount returned by the API.
-
-    If the source has 'contact' in it, Autopilot API will provide a
-    'bookmark' property at the top level that is used to paginate
-    results
-
-
-
-    The API only returns bookmarks for iterating through contacts
+    '''Yields results from requests executed against the provided endpoint,
+    transparently paginating through multiple requests if the endpoint has
+    a "bookmark" parameter for pagination.
     '''
     params = params or {}
 
@@ -195,19 +187,14 @@ def gen_request(STATE, endpoint, params=None):
     with metrics.record_counter(source) as counter:
         while True:
             data = request(endpoint, params).json()
-            if 'contact' in source:
-                if "bookmark" in data:
-                    params["bookmark"] = data["bookmark"]
-
-                else:
-                    params = {}
 
             for row in data[source_key]:
                 counter.increment()
                 yield row
 
-            if len(data[source_key]) < PER_PAGE:
-                params = {}
+            if "bookmark" in data:
+                params["bookmark"] = data["bookmark"]
+            else:
                 break
 
 
@@ -231,14 +218,12 @@ def sync_contacts(STATE, stream):
                         stream['schema'],
                         ["contact_id"])
 
-    # NB: Params is modified in gen_request by reference
-    params = {}
     start = utils.strptime_with_tz(get_start(STATE, tap_stream_id, "updated_at"))
 
     LOGGER.info("Only syncing contacts updated since " + utils.strftime(start))
     max_updated_at = start
 
-    for row in gen_request(STATE, get_url(tap_stream_id), params):
+    for row in gen_request(STATE, get_url(tap_stream_id)):
         updated_at = None
         if "updated_at" in row:
             updated_at = utils.strptime_with_tz(
@@ -307,10 +292,8 @@ def sync_smart_segments(STATE, stream):
 
     '''
     singer.write_schema("smart_segments", stream['schema'], ["segment_id"])
-    # NB: Params is modified in gen_request by reference
-    params = {}
 
-    for row in gen_request(STATE, get_url("smart_segments"), params):
+    for row in gen_request(STATE, get_url("smart_segments")):
         singer.write_record("smart_segments", row)
 
     LOGGER.info("Completed Smart Segments Sync")
@@ -329,12 +312,10 @@ def sync_smart_segment_contacts(STATE, stream):
         "smart_segments_contacts",
         stream['schema'],
         ["segment_id", "contact_id"])
-    # NB: Params is modified in gen_request by reference
-    params = {}
 
-    for row in gen_request(STATE, get_url("smart_segments"), params):
+    for row in gen_request(STATE, get_url("smart_segments")):
         subrow_url = get_url("smart_segments_contacts", segment_id=row["segment_id"])
-        for subrow in gen_request(STATE, subrow_url, params):
+        for subrow in gen_request(STATE, subrow_url):
             singer.write_record("smart_segments_contacts", {
                 "segment_id": row["segment_id"],
                 "contact_id": subrow["contact_id"]


### PR DESCRIPTION
# Description of change

Fixes issue #1

The current pagination logic in the `gen_request` function may loop infinitely for certain streams, processing the same response data over and over. 

The loop that paginates through HTTP responses and iterates through results in each response breaks only when the number of results in the last response was less than 100. However, 100 is not the max results size for all endpoints. For example, we have 104 smart segments. When `gen_request` makes a request to `https://api2.autopilothq.com/v1/smart_segments`, all 104 segment IDs are returned in the first response, so no further pagination is required. This is evident from the absence of a `"bookmark"` field in the response data. `gen_request` will keep hitting this endpoint forever because the breaking condition doesn't check for the presence of `"bookmark"`, instead executing `if len(data[source_key]) < PER_PAGE: break` (`if 104 < 100: break`).

This PR refactors the pagination logic of `gen_request` to continue paginating based only on the presence or absence of the `"bookmark"` response field -- used for pagination across the Autopilot API.

Additionally, I removed instances in `sync_[stream]` functions of passing an empty `params` dictionary to `gen_request`, as 1) `gen_request` always returns the dictionary empty (no actual mutation occurs) and 2) the dictionary is never used later in any of the `sync` functions (even if there were a mutated state after the call to gen_request, it's never accessed).

# Manual QA steps
As Autopilot has no developer sandbox, an active Autopilot account populated with data in each of the streams is needed to test these changes.

Running the tap with the changes on this branch should result in streams producing a number of rows equal to the number of objects for the target reported by Autopilot. 

### Getting expected counts

After I observed a discrepancy, Autopilot support confirmed for me that the the `total_contacts` field on the contacts API endpoint is not accurate (yeah, I know). I was told to get this count instead by creating a smart segment with no filters (include all contacts) and to use the count for that segment.
For the `smart_segments` and `lists` streams, there's no corresponding count in the UI, so I ran the following to get expected counts:

smart_segments:
`curl https://api2.autopilothq.com/v1/smart_segments\?apikey\=[omitted] | jq '.segments[].segment_id' | wc -l` 
lists:
`curl https://api2.autopilothq.com/v1/lists\?apikey\=[omitted] | jq '.lists[].list_id' | wc -l`

### Testing the tap

After schema discovery, run each stream (can be good to run each separately as some are quite long-running) and validate that the number of records output by the stream equaled the number records for that source indicated in the Autopilot UI.

Running the stream: `tap-autopilot --config=config.json --properties catalog.json > [outfile] 2>&1`
Counting records for contacts, smart_segments, and lists: `cat [outfile] | grep '{"type": "RECORD", "stream": "[stream_being_counted]"' | wc -l`
Counting records for smart_segments_contacts: same as above, but additionally `grep` filter by segment ID.

We have over 100 smart segments, many with hundreds of thousands of contacts. In order to test in a sane amount of time, I chose to test only a couple of segments with 278 and ~33,000 contacts in them, respectively, and temporarily added without committing a line to the sync_smart_segments_contacts function `if row["segment_id"] not in ["[ommitted], [omitted]"]: continue`.

* [x] stream "contacts" 
* [x] stream "smart_segments" (this was where we previously had an infinite loop)
* [x] stream "smart_segments_contacts"
* [x] stream "lists"

# Risks
Significant change (towards greater accuracy and **lower** row counts, however), in the data produced by this tap for any users whose Autopilot data triggers the infinite loop. 
Users who have not experienced this bug should see no changes in their data.

# Rollback steps
 - revert this branch
